### PR TITLE
Add minElapsedTimeMinutes

### DIFF
--- a/app/src/main/kotlin/de/timklge/karooreminder/KarooReminderExtension.kt
+++ b/app/src/main/kotlin/de/timklge/karooreminder/KarooReminderExtension.kt
@@ -320,12 +320,13 @@ class KarooReminderExtension : KarooExtension("karoo-reminder", BuildConfig.VERS
 
     private fun startIntervalJob(preferences: List<Reminder>, activeRideProfile: ActiveRideProfile, trigger: ReminderTrigger, flow: () -> Flow<Int>): Job {
         return CoroutineScope(Dispatchers.IO).launch {
-            var currentElapsedMinutes = 0
+            val currentElapsedMinutes = java.util.concurrent.atomic.AtomicInteger(0)
             launch {
                 karooSystem.streamDataFlow(DataType.Type.ELAPSED_TIME)
                     .mapNotNull { (it as? StreamState.Streaming)?.dataPoint?.singleValue }
                     .map { (it / 1000 / 60).toInt() }
-                    .collect { currentElapsedMinutes = it }
+                    .distinctUntilChanged()
+                    .collect { currentElapsedMinutes.set(it) }
             }
 
             flow()
@@ -335,7 +336,7 @@ class KarooReminderExtension : KarooExtension("karoo-reminder", BuildConfig.VERS
                     val rs = preferences
                         .filter { reminder ->
                             val interval = reminder.interval
-                            val elapsedForCheck = if (trigger == ReminderTrigger.ELAPSED_TIME) elapsedMinutes else currentElapsedMinutes
+                            val elapsedForCheck = if (trigger == ReminderTrigger.ELAPSED_TIME) elapsedMinutes else currentElapsedMinutes.get()
                             reminder.trigger == trigger && reminderIsActive(reminder, activeRideProfile.profile) && interval != null && elapsedMinutes % interval == 0
                                 && (reminder.minElapsedTimeMinutes == 0 || elapsedForCheck >= reminder.minElapsedTimeMinutes)
                         }
@@ -392,6 +393,7 @@ class KarooReminderExtension : KarooExtension("karoo-reminder", BuildConfig.VERS
             val elapsedTimeFlow = karooSystem.streamDataFlow(DataType.Type.ELAPSED_TIME)
                 .mapNotNull { (it as? StreamState.Streaming)?.dataPoint?.singleValue }
                 .map { (it / 1000 / 60).toInt() }
+                .distinctUntilChanged()
 
             combine(valueStream, karooSystem.streamUserProfile(), karooSystem.streamRideState(), elapsedTimeFlow) { value, profile, rideState, elapsedMin ->
                 StreamData(distanceImperial = profile.preferredUnit.distance == UserProfile.PreferredUnit.UnitType.IMPERIAL, temperatureImperial = profile.preferredUnit.temperature == UserProfile.PreferredUnit.UnitType.IMPERIAL,

--- a/app/src/main/kotlin/de/timklge/karooreminder/KarooReminderExtension.kt
+++ b/app/src/main/kotlin/de/timklge/karooreminder/KarooReminderExtension.kt
@@ -320,6 +320,13 @@ class KarooReminderExtension : KarooExtension("karoo-reminder", BuildConfig.VERS
 
     private fun startIntervalJob(preferences: List<Reminder>, activeRideProfile: ActiveRideProfile, trigger: ReminderTrigger, flow: () -> Flow<Int>): Job {
         return CoroutineScope(Dispatchers.IO).launch {
+            var currentElapsedMinutes = 0
+            launch {
+                karooSystem.streamDataFlow(DataType.Type.ELAPSED_TIME)
+                    .mapNotNull { (it as? StreamState.Streaming)?.dataPoint?.singleValue }
+                    .map { (it / 1000 / 60).toInt() }
+                    .collect { currentElapsedMinutes = it }
+            }
 
             flow()
                 .filterNot { it == 0 }
@@ -328,7 +335,9 @@ class KarooReminderExtension : KarooExtension("karoo-reminder", BuildConfig.VERS
                     val rs = preferences
                         .filter { reminder ->
                             val interval = reminder.interval
+                            val elapsedForCheck = if (trigger == ReminderTrigger.ELAPSED_TIME) elapsedMinutes else currentElapsedMinutes
                             reminder.trigger == trigger && reminderIsActive(reminder, activeRideProfile.profile) && interval != null && elapsedMinutes % interval == 0
+                                && (reminder.minElapsedTimeMinutes == 0 || elapsedForCheck >= reminder.minElapsedTimeMinutes)
                         }
 
                     for (reminder in rs) {
@@ -378,11 +387,15 @@ class KarooReminderExtension : KarooExtension("karoo-reminder", BuildConfig.VERS
                 }
                 .filter { it != 0.0 }
 
-            data class StreamData(val value: Double, val reminders: MutableList<Reminder>, val distanceImperial: Boolean, val temperatureImperial: Boolean, val rideState: RideState)
+            data class StreamData(val value: Double, val reminders: MutableList<Reminder>, val distanceImperial: Boolean, val temperatureImperial: Boolean, val rideState: RideState, val elapsedMinutes: Int)
 
-            combine(valueStream, karooSystem.streamUserProfile(), karooSystem.streamRideState()) { value, profile, rideState ->
+            val elapsedTimeFlow = karooSystem.streamDataFlow(DataType.Type.ELAPSED_TIME)
+                .mapNotNull { (it as? StreamState.Streaming)?.dataPoint?.singleValue }
+                .map { (it / 1000 / 60).toInt() }
+
+            combine(valueStream, karooSystem.streamUserProfile(), karooSystem.streamRideState(), elapsedTimeFlow) { value, profile, rideState, elapsedMin ->
                 StreamData(distanceImperial = profile.preferredUnit.distance == UserProfile.PreferredUnit.UnitType.IMPERIAL, temperatureImperial = profile.preferredUnit.temperature == UserProfile.PreferredUnit.UnitType.IMPERIAL,
-                    value = value, reminders = preferences, rideState = rideState)
+                    value = value, reminders = preferences, rideState = rideState, elapsedMinutes = elapsedMin)
             }.filter {
                 it.rideState is RideState.Recording
             }.let {
@@ -403,7 +416,7 @@ class KarooReminderExtension : KarooExtension("karoo-reminder", BuildConfig.VERS
                         ReminderTrigger.ELAPSED_TIME, ReminderTrigger.DISTANCE, ReminderTrigger.ENERGY_OUTPUT -> error("Unsupported trigger type: $triggerType")
                     }
                 }
-                .map { (actualValue, reminders, distanceImperial, temperatureImperial) ->
+                .map { (actualValue, reminders, distanceImperial, temperatureImperial, _, elapsedMinutes) ->
                     val triggered = reminders.filter { reminder ->
                         val triggerThreshold = when(triggerType) {
                             ReminderTrigger.SPEED_LIMIT_MINIMUM_EXCEEDED, ReminderTrigger.SPEED_LIMIT_MAXIMUM_EXCEEDED -> {
@@ -443,6 +456,7 @@ class KarooReminderExtension : KarooExtension("karoo-reminder", BuildConfig.VERS
                         }
 
                         reminderIsActive(reminder, activeRideProfile.profile) && reminder.trigger == triggerType && triggerIsMet
+                            && (reminder.minElapsedTimeMinutes == 0 || elapsedMinutes >= reminder.minElapsedTimeMinutes)
                     }
 
                     triggered

--- a/app/src/main/kotlin/de/timklge/karooreminder/screens/DetailScreen.kt
+++ b/app/src/main/kotlin/de/timklge/karooreminder/screens/DetailScreen.kt
@@ -109,6 +109,7 @@ fun DetailScreen(isCreating: Boolean, reminder: Reminder, onSubmit: (updatedRemi
     var enabledRideProfiles by remember { mutableStateOf(reminder.enabledRideProfiles.toMutableSet()) }
     var minElapsedTimeEnabled by remember { mutableStateOf(reminder.minElapsedTimeMinutes > 0) }
     var minElapsedTimeMinutes by remember { mutableStateOf(if (reminder.minElapsedTimeMinutes > 0) reminder.minElapsedTimeMinutes.toString() else "10") }
+    val minElapsedTimeError = minElapsedTimeEnabled && (minElapsedTimeMinutes.toIntOrNull() == null || (minElapsedTimeMinutes.toIntOrNull() ?: -1) < 0)
 
     val profile by karooSystem.streamUserProfile().collectAsStateWithLifecycle(null)
 
@@ -124,7 +125,7 @@ fun DetailScreen(isCreating: Boolean, reminder: Reminder, onSubmit: (updatedRemi
             trigger = selectedTrigger,
             isAutoDismiss = autoDismiss, tone = selectedTone, autoDismissSeconds = autoDismissSeconds.toIntOrNull() ?: 15,
             enabledRideProfiles = enabledRideProfiles.toSet(),
-            minElapsedTimeMinutes = if (minElapsedTimeEnabled) (minElapsedTimeMinutes.toIntOrNull() ?: 0) else 0)
+            minElapsedTimeMinutes = if (minElapsedTimeEnabled) maxOf(0, minElapsedTimeMinutes.toIntOrNull() ?: 0) else 0)
     }
 
     Column(modifier = Modifier
@@ -280,6 +281,8 @@ fun DetailScreen(isCreating: Boolean, reminder: Reminder, onSubmit: (updatedRemi
                     onValueChange = { minElapsedTimeMinutes = it },
                     label = { Text("Minimum elapsed time") },
                     suffix = { Text("min") },
+                    isError = minElapsedTimeError,
+                    supportingText = if (minElapsedTimeError) {{ Text("Enter a positive number") }} else null,
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                     singleLine = true
                 )
@@ -328,7 +331,9 @@ fun DetailScreen(isCreating: Boolean, reminder: Reminder, onSubmit: (updatedRemi
 
             FilledTonalButton(modifier = Modifier
                 .fillMaxWidth()
-                .height(50.dp), onClick = {
+                .height(50.dp),
+                enabled = !minElapsedTimeError,
+                onClick = {
                 onSubmit(getUpdatedReminder())
             }) {
                 Icon(Icons.Default.Done, contentDescription = "Save Reminder")

--- a/app/src/main/kotlin/de/timklge/karooreminder/screens/DetailScreen.kt
+++ b/app/src/main/kotlin/de/timklge/karooreminder/screens/DetailScreen.kt
@@ -107,6 +107,8 @@ fun DetailScreen(isCreating: Boolean, reminder: Reminder, onSubmit: (updatedRemi
     var selectedTrigger by remember { mutableStateOf(reminder.trigger) }
     var rideProfileDialogVisible by remember { mutableStateOf(false) }
     var enabledRideProfiles by remember { mutableStateOf(reminder.enabledRideProfiles.toMutableSet()) }
+    var minElapsedTimeEnabled by remember { mutableStateOf(reminder.minElapsedTimeMinutes > 0) }
+    var minElapsedTimeMinutes by remember { mutableStateOf(if (reminder.minElapsedTimeMinutes > 0) reminder.minElapsedTimeMinutes.toString() else "10") }
 
     val profile by karooSystem.streamUserProfile().collectAsStateWithLifecycle(null)
 
@@ -121,7 +123,8 @@ fun DetailScreen(isCreating: Boolean, reminder: Reminder, onSubmit: (updatedRemi
             smoothSetting = smoothSetting,
             trigger = selectedTrigger,
             isAutoDismiss = autoDismiss, tone = selectedTone, autoDismissSeconds = autoDismissSeconds.toIntOrNull() ?: 15,
-            enabledRideProfiles = enabledRideProfiles.toSet())
+            enabledRideProfiles = enabledRideProfiles.toSet(),
+            minElapsedTimeMinutes = if (minElapsedTimeEnabled) (minElapsedTimeMinutes.toIntOrNull() ?: 0) else 0)
     }
 
     Column(modifier = Modifier
@@ -259,6 +262,24 @@ fun DetailScreen(isCreating: Boolean, reminder: Reminder, onSubmit: (updatedRemi
                     onValueChange = { autoDismissSeconds = it },
                     label = { Text("Display duration") },
                     suffix = { Text("s") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    singleLine = true
+                )
+            }
+
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Switch(checked = minElapsedTimeEnabled, onCheckedChange = { minElapsedTimeEnabled = it })
+                Spacer(modifier = Modifier.width(10.dp))
+                Text("Delay first alert")
+            }
+
+            if (minElapsedTimeEnabled) {
+                OutlinedTextField(
+                    value = minElapsedTimeMinutes,
+                    modifier = Modifier.fillMaxWidth(),
+                    onValueChange = { minElapsedTimeMinutes = it },
+                    label = { Text("Minimum elapsed time") },
+                    suffix = { Text("min") },
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                     singleLine = true
                 )

--- a/app/src/main/kotlin/de/timklge/karooreminder/screens/Reminder.kt
+++ b/app/src/main/kotlin/de/timklge/karooreminder/screens/Reminder.kt
@@ -143,7 +143,9 @@ class Reminder(val id: Int, var name: String,
                val tone: ReminderBeepPattern = ReminderBeepPattern.THREE_TONES_UP,
                var trigger: ReminderTrigger = ReminderTrigger.ELAPSED_TIME,
                val autoDismissSeconds: Int = 15,
-               val enabledRideProfiles: Set<String> = emptySet())
+               val enabledRideProfiles: Set<String> = emptySet(),
+               /** Minimum elapsed ride time in minutes before the first alert fires. 0 = no minimum. */
+               val minElapsedTimeMinutes: Int = 0)
 
 val defaultReminders = Json.encodeToString(listOf(Reminder(0, "Drink", 30, text = "Take a sip!")))
 


### PR DESCRIPTION
Hello, this reminder extension is very useful, but I think it's necessary to have a  delay alert (first alert). For example, I've a Drink alarm every 20 minutes but I want the first alarm after 30 minutes

i've added minElapsedTimeMinutes in code (UI and app).

Regards

